### PR TITLE
remove from archetype-metadata.xml requiredProperty:package

### DIFF
--- a/archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,6 @@
 		<requiredProperty key="version">
 			<defaultValue>0.0.1-SNAPSHOT</defaultValue>
 		</requiredProperty>
-		<requiredProperty key="package"/>
 	</requiredProperties>
 	<fileSets>
 		<fileSet>


### PR DESCRIPTION
The requirement of a java package when starting archetype is not used : requiredProperty  "package" in archetype-metadata.xml has been removed.
